### PR TITLE
fix: zero shields on saucers

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,7 @@ import Config
 
 # The accuracy is a random normal value applied to the true bearing from saucer to target.
 #   0.0  -> 1.000  Precise
-#   0.0125         Leathal
+#   0.0125         Lethal
 #   0.25
 #   0.05 -> 0.700
 #   0.1  -> 0.400  Scatter gun
@@ -22,11 +22,17 @@ small_saucer = %{
   large_saucer
   | accuracy: 0.0125,
     radius: 18.0,
-    speed_m_per_s: 300.0,
-    saucer_radar_range: 1000.0
+    saucer_radar_range: 1000.0,
+    shields: 0,
+    speed_m_per_s: 300.0
 }
 
-warthog = %{large_saucer | shooting_interval: 125, radius: 30.0}
+warthog = %{
+  large_saucer
+  | radius: 30.0,
+    shields: 0,
+    shooting_interval: 125
+}
 
 config :elixoids,
   asteroid_radius_m: 120.0,
@@ -37,7 +43,7 @@ config :elixoids,
   initial_asteroids: 8,
   max_inflight_bullets: 4,
   max_shields: 3,
-  player_fps: 4,
+  player_fps: 2,
   saucers: [large_saucer, large_saucer, small_saucer, large_saucer, warthog],
   saucer_interval_ms: 15_000,
   ship_laser_recharge_ms: 200,

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Elixoids.Mixfile do
       app: :elixoids,
       description: "Asteroids Arcade Game Server",
       name: "Elixoids",
-      version: "3.24.141",
+      version: "3.24.142",
       elixir: "~> 1.13",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Due to inheritance, all saucers had three shields.
Intention was only the large saucer had shields